### PR TITLE
Android app settings direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,7 @@ Upgrading Kotlin version from: ext.kotlin_version = '1.2.71' to ext.kotlin_versi
 
 Ensure the plugin stays compatible with iOS8+.
 Declare Swift compatibility version 4.2.
+
+## 1.0.6
+
+Add openAppSettings() to access platform specific 'app' settings menu.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ import 'package:app_settings/app_settings.dart';
 ```
 
 ## Platform Specifics
-The following setting options available on both iOS and Android: openWIFISettings, openLocationSettings, openSecuritySettings  
-
+The following setting options available on both iOS and Android: openAppSettings, openWIFISettings, openLocationSettings, openSecuritySettings
 ### iOS
-All three options open the current 'app' settings section if there are settings defined.  If no current settings are defined for the app the iPhone Settings Screen will be displayed.
+All four options open the current 'app' settings section if there are settings defined.  If no current settings are defined for the app the iPhone Settings Screen will be displayed.
 
 ### Android
-Each option will open and display the exact corresponding screen: WIFI, Location, or Security.
+Each option will open and display the exact corresponding system settings screen: WIFI, Location, or Security.
+
+Using the openAppSettings option will open the current 'app' settings for the running app.
 
 ## Example
 Example implementation using a raised button 'onPressed' event.  

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Flutter plugin for opening iOS and Android phone settings from an app.
 dependencies:
   flutter:
     sdk: flutter
-  app_settings: 1.0.5
+  app_settings: 1.0.6
 ```
 
 Next, import 'app_settings.dart' into your dart code.

--- a/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
@@ -2,12 +2,14 @@ package com.example.appsettings
 
 import android.content.Intent;
 import android.provider.Settings;
+import android.net.Uri
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
+
 
 class AppSettingsPlugin: MethodCallHandler {
   /// Private variable to hold instance of Registrar for creating Intents.
@@ -39,6 +41,12 @@ class AppSettingsPlugin: MethodCallHandler {
       openSettings(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS)
     } else if (call.method == "security") {
       openSettings(android.provider.Settings.ACTION_SECURITY_SETTINGS)
+    } else if (call.method == "app_settings") {
+      val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      val uri = Uri.fromParts("package", this.registrar.activity().getPackageName(), null)
+      intent.setData(uri)
+      this.registrar.activity().startActivity(intent)
     }
   }
 }

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -19,4 +19,9 @@ class AppSettings {
   static Future openSecuritySettings() async {
     _channel.invokeMethod('security');
   }
+
+  /// Future async method call to open app specific settings screen.
+  static Future openAppSettings() async {
+    _channel.invokeMethod('app_settings');
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_settings
 description: A Flutter plugin for opening iOS and Android phone settings from an app.
-version: 1.0.5
+version: 1.0.6
 author: Spencerccf <spencerccf@gmail.com>
 homepage: https://github.com/spencerccf/app_settings
 


### PR DESCRIPTION
Refer to #4 

This PR allows the caller of `AppSettings.openAppSettings()` to access the platform 'app' settings menu.