### PR TITLE
Adds Internal Storage settings access for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All three options open the current 'app' settings section if there are settings 
 ### Android
 Each option will open and display the corresponding screen: WIFI, Location, or Security, etc.
 
+## 3.0.1
+Added Internal Storage settings access for Android.  iOS will still rely on App Settings.
+
 ## 3.0.0+1
 Update plugin version in `.podspec`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import 'package:app_settings/app_settings.dart';
 ```
 
 ## Platform Specifics
-The following setting options available on both iOS and Android: openAppSettings, openWIFISettings, openLocationSettings, openSecuritySettings, openBluetoothSettings, openDataRoamingSettings, openDateSettings, openDisplaySettings, openNotificationSettings, openSoundSettings
+The following setting options available on both iOS and Android: openAppSettings, openWIFISettings, openLocationSettings, openSecuritySettings, openBluetoothSettings, openDataRoamingSettings, openDateSettings, openDisplaySettings, openNotificationSettings, openSoundSettings, openInternalStorageSettings
 ### iOS
   ***TIP: If using Objective-C for iOS in your project, you will need to add `use_frameworks!` to your `Runner project podfile` in order to use this Swift plugin:***
     

--- a/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
@@ -66,6 +66,8 @@ class AppSettingsPlugin: MethodCallHandler {
       openSettings(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
     } else if (call.method == "sound") {
       openSettings(Settings.ACTION_SOUND_SETTINGS)
+    } else if (call.method == "internal_storage") {
+      openSettings(Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
     } else if (call.method == "app_settings") {
       openAppSettings()
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,6 +115,12 @@ class _MyAppState extends State<MyApp> {
           AppSettings.openSoundSettings();
         },
       ),
+      RaisedButton(
+        child: Text("Internal Storage"),
+        onPressed: () {
+          AppSettings.openInternalStorageSettings();
+        },
+      ),
     ]);
 
     return actionItems;

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -50,6 +50,11 @@ class AppSettings {
     _channel.invokeMethod('sound');
   }
 
+  /// Future async method call to open internal storage settings.
+  static Future<void> openInternalStorageSettings() async {
+    _channel.invokeMethod('internal_storage');
+  }
+
   /// Future async method call to open app specific settings screen.
   static Future<void> openAppSettings() async {
     _channel.invokeMethod('app_settings');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_settings
 description: A Flutter plugin for opening iOS and Android phone settings from an app.
-version: 3.0.0+1
+version: 3.0.1
 author: Spencerccf <spencerccf@gmail.com>
 homepage: https://github.com/spencerccf/app_settings
 


### PR DESCRIPTION
One general use case that was missing in this flutter-plugin was the ability to jump directly to the storage settings page (for Android).
This PR simply adds that use case and updates the readme, changelog and example app to incorporate this change.

![app_settings-android](https://user-images.githubusercontent.com/35557557/74937899-4e0c3980-53ed-11ea-9acf-7838b5913c5d.gif)
![app_settings-ios](https://user-images.githubusercontent.com/35557557/74937909-52385700-53ed-11ea-85b8-415c5184d468.gif)
