### PR TITLE
Fix 'openSettingsURLString' has been renamed

### DIFF
--- a/ios/Classes/SwiftAppSettingsPlugin.swift
+++ b/ios/Classes/SwiftAppSettingsPlugin.swift
@@ -5,7 +5,7 @@ import UIKit
 public class SwiftAppSettingsPlugin: NSObject, FlutterPlugin {
   /// Private method to open device settings window
   private func openSettings() {
-      if let url = URL(string: UIApplication.openSettingsURLString) {
+      if let url = URL(string: UIApplicationOpenSettingsURLString) {
         if #available(iOS 10.0, *) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {


### PR DESCRIPTION
This seems to close #52 :)

Though I don't know how it will break compatiblity depending on swift versions?