### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Widget build(BuildContext context) {
     return Row(
         children: <Widget>[
             RaisedButton(
-                onPressed: AppSettings.openLocationSettings(),
+                onPressed: AppSettings.openLocationSettings,
                 child: Text('Open Location Settings'),
             ),
         ],


### PR DESCRIPTION
`RaisedButton`'s `onPressed` should receive a function, not a function call. Removing the parenthesis `()` makes the example valid.