### PR TITLE
Support Android core 1.7.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Hi Peeps,

This PR is to support Android core 1.7.0 due to the opened issue [**Build APK failed: app_settings:verifyReleaseResources'. in Android core 1.7.0**](https://github.com/spencerccf/app_settings/issues/114)

By upgrading `compileSDKVersion` to **31** solve the issue because the issue 
[**`AAPT: error: resource android:attr/lStar not found.`**](https://stackoverflow.com/questions/69041630/android-build-error-lstar-not-found)

 **lStar which is a system attribute that's new as of API level 31**

This is why causing the error and failed to compile.

