### PR TITLE
Show app details for notifications if below Android 26

### DIFF
--- a/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
@@ -100,13 +100,13 @@ class AppSettingsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
         } else if (call.method == "display") {
             openSettings(Settings.ACTION_DISPLAY_SETTINGS, asAnotherTask)
         } else if (call.method == "notification") {
-            if (Build.VERSION.SDK_INT >= 21) {
+            if (Build.VERSION.SDK_INT >= 26) {
                 val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
                         .putExtra(Settings.EXTRA_APP_PACKAGE, this.activity.packageName)
                 if (asAnotherTask) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 this.activity.startActivity(intent)
             } else {
-                openSettings(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS, asAnotherTask)
+                openAppSettings(asAnotherTask)
             }
         } else if (call.method == "nfc") {
             openSettings(Settings.ACTION_NFC_SETTINGS, asAnotherTask)


### PR DESCRIPTION
Continuing #34 and #36.

This branch changes the minimum SDK needed to use the action `Settings.ACTION_APP_NOTIFICATION_SETTINGS` based off when it was added to the Android SDK **. For Android versions below 26, the app details page should be shown since it gives the user a way to disable app notifications.

** https://developer.android.com/reference/android/provider/Settings#ACTION_APP_NOTIFICATION_SETTINGS