### PR TITLE
Add support to Flutter <= 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All three options open the current 'app' settings section if there are settings 
 ### Android
 Each option will open and display the corresponding screen: WIFI, Location, or Security, etc.
 
+## 4.1.7
+Add support to Flutter <=3.0.1.
+
 ## 4.1.6
 Ability to open personal hotspot settings.
 Ability to open custom intents.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Flutter plugin for opening iOS and Android phone settings from an app.
 dependencies:
   flutter:
     sdk: flutter
-  app_settings: 4.1.6
+  app_settings: 4.1.7
 ```
 
 Next, import 'app_settings.dart' into your dart code.

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="app_settings_example"
         android:icon="@mipmap/ic_launcher">
         <meta-data

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app_settings_example
 description: Demonstrates how to use the app_settings plugin.
 publish_to: 'none'
-version: 4.1.6
+version: 4.1.7
 
 environment:
   sdk: ">=2.12.0 <=3.0.1"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 4.1.6
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <=3.0.1"
   flutter: ">=1.10.0"
 
 dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,45 +7,45 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_settings
 description: A Flutter plugin for opening iOS and Android phone settings from an app.
-version: 4.1.6
+version: 4.1.7
 homepage: https://github.com/spencerccf/app_settings
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 4.1.6
 homepage: https://github.com/spencerccf/app_settings
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <=3.0.1"
   flutter: ">=1.10.0"
 
 dependencies:


### PR DESCRIPTION
## Changes

- Add supported flutter version `<= 3.0.1`

## Evidence

Example app running on flutter 3.0.1

![image](https://user-images.githubusercontent.com/12724212/171875619-690b7134-a674-48af-bf9f-30b39c5050ba.png)
