### PR TITLE
:sparkles: Added `ACTION_REQUEST_SCHEDULE_EXACT_ALARM` settings

### DIFF
--- a/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/example/appsettings/AppSettingsPlugin.kt
@@ -150,6 +150,9 @@ class AppSettingsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
             openSettingsWithCustomIntent(intent, asAnotherTask)
         } else if (call.method == "apn") {
             openSettings(Settings.ACTION_APN_SETTINGS, asAnotherTask)
+        } else if (call.method == "alarm") {
+            val uri = Uri.fromParts("package", this.activity.packageName, null)
+            openSettingsWithCustomIntent(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, uri), asAnotherTask)
         }
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -185,6 +185,12 @@ class _MyAppState extends State<MyApp> {
           AppSettings.openAPNSettings(asAnotherTask: true);
         },
       ),
+      ElevatedButton(
+        child: Text("Alarm & Reminders"),
+        onPressed: () {
+          AppSettings.openAlarmSettings(asAnotherTask: true);
+        },
+      ),
     ]);
 
     return actionItems;

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -173,10 +173,9 @@ class AppSettings {
       {bool asAnotherTask = false}) async {
     _channel.invokeMethod('development', {'asAnotherTask': asAnotherTask});
   }
-  
+
   /// Opening hotspot and tethering settings
-  static Future<void> openHotspotSettings(
-      {bool asAnotherTask = false}) async {
+  static Future<void> openHotspotSettings({bool asAnotherTask = false}) async {
     _channel.invokeMethod('hotspot', {'asAnotherTask': asAnotherTask});
   }
 
@@ -185,6 +184,15 @@ class AppSettings {
     bool asAnotherTask = false,
   }) async {
     _channel.invokeMethod('apn', {
+      'asAnotherTask': asAnotherTask,
+    });
+  }
+
+  /// Future async method call to open Alarms & Reminders settings.
+  static Future<void> openAlarmSettings({
+    bool asAnotherTask = false,
+  }) async {
+    _channel.invokeMethod('alarm', {
       'asAnotherTask': asAnotherTask,
     });
   }


### PR DESCRIPTION
Added [`ACTION_REQUEST_SCHEDULE_EXACT_ALARM`](https://developer.android.com/reference/android/provider/Settings#ACTION_REQUEST_SCHEDULE_EXACT_ALARM) setting. Closes #156 

This setting is added in API level 31 (Android 12)

Left: Android 11 (fallback to app setting)
Right: Android 12 

![Screenshot_20221113_081753](https://user-images.githubusercontent.com/60868965/201499873-cee46696-11bf-4a58-9b5b-ceeb1d31e36f.png)
