### PR TITLE
fix: Does not crash in debug mode of iOS 14+

### DIFF
--- a/ios/Classes/AppSettingsPlugin.m
+++ b/ios/Classes/AppSettingsPlugin.m
@@ -10,6 +10,8 @@
 
 @implementation AppSettingsPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftAppSettingsPlugin registerWithRegistrar:registrar];
+    if (registrar) {
+        [SwiftAppSettingsPlugin registerWithRegistrar:registrar];
+    }
 }
 @end


### PR DESCRIPTION
In ios 14+, debug mode Flutter apps can only be launched from Flutter tooling, IDEs with Flutter plugins or from Xcode.
so, registrar will be nil.
However, we can't make it crash in its own plugin.