### PR TITLE
change the AppSettingPlugin to ACTION_DEVICE_INFO_SETTINGS

### DIFF
--- a/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
@@ -81,7 +81,7 @@ class AppSettingsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         asAnotherTask,
       )
       "device" -> openSettings(Settings.ACTION_DEVICE_INFO_SETTINGS, result, asAnotherTask)
-      "generalSettings" -> openSettings(Setting.ACTION_SETTINGS, result, asAnotherTask)
+      "generalSettings" -> openSettings(Settings.ACTION_SETTINGS, result, asAnotherTask)
       "display" -> openSettings(Settings.ACTION_DISPLAY_SETTINGS, result, asAnotherTask)
       "hotspot" -> openHotspotSettings(result, asAnotherTask)
       "internalStorage" -> openSettings(

--- a/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
@@ -81,6 +81,7 @@ class AppSettingsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         asAnotherTask,
       )
       "device" -> openSettings(Settings.ACTION_DEVICE_INFO_SETTINGS, result, asAnotherTask)
+      "generalSettings" -> openSettings(Setting.ACTION_SETTINGS, result, asAnotherTask)
       "display" -> openSettings(Settings.ACTION_DISPLAY_SETTINGS, result, asAnotherTask)
       "hotspot" -> openHotspotSettings(result, asAnotherTask)
       "internalStorage" -> openSettings(

--- a/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
+++ b/android/src/main/kotlin/com/spencerccf/app_settings/AppSettingsPlugin.kt
@@ -80,7 +80,7 @@ class AppSettingsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         result,
         asAnotherTask,
       )
-      "device" -> openSettings(Settings.ACTION_SETTINGS, result, asAnotherTask)
+      "device" -> openSettings(Settings.ACTION_DEVICE_INFO_SETTINGS, result, asAnotherTask)
       "display" -> openSettings(Settings.ACTION_DISPLAY_SETTINGS, result, asAnotherTask)
       "hotspot" -> openHotspotSettings(result, asAnotherTask)
       "internalStorage" -> openSettings(

--- a/lib/src/app_settings_type.dart
+++ b/lib/src/app_settings_type.dart
@@ -53,6 +53,11 @@ enum AppSettingsType {
   /// Only supported on Android.
   device,
 
+  /// Open the general device settings (The first page when user open Settings.)
+  /// 
+  /// Only supported on Android.
+  generalSettings,
+  
   /// Open the display settings.
   ///
   /// Only supported on Android.


### PR DESCRIPTION
I was noticing that the implementation use ACTION_SETTINGS which open a normal system setting page instead of device info page where serial, IMEI etc. should be found.  So i change the line according to [Official API documentation](https://developer.android.com/reference/kotlin/android/provider/Settings#action_device_info_settings)

Tested on My device (OPPO Reno 5 Pro 5G, Android 13) and seems to working perfectly.