### PR TITLE
Add macOS privacy manifest

### DIFF
--- a/macos/PrivacyInfo.xcprivacy
+++ b/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <false/>
+</dict>
+</plist>

--- a/macos/app_settings.podspec
+++ b/macos/app_settings.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0.1'
+  s.resource_bundles = {'app_settings_privacy' => ['PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Add privacy manifest to macOS.

Related issues:
https://github.com/flutter/flutter/issues/154915
