### PR TITLE
Fix for issue #232

### DIFF
--- a/ios/app_settings/Sources/app_settings/AppSettingsPlugin.swift
+++ b/ios/app_settings/Sources/app_settings/AppSettingsPlugin.swift
@@ -3,7 +3,7 @@ import UIKit
 import StoreKit
 
 @MainActor
-public class AppSettingsPlugin: NSObject, @preconcurrency FlutterPlugin, UIWindowSceneDelegate {
+public class AppSettingsPlugin: NSObject, FlutterPlugin, UIWindowSceneDelegate {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "com.spencerccf.app_settings/methods", binaryMessenger: registrar.messenger())
         let instance = AppSettingsPlugin()


### PR DESCRIPTION
Fİx for AppSettingsPlugin.swift:5:43, Attribute can only be applied to declarations, not types issue #232,
I tested one time and build succesful and it opens settings on ios simulator, but I did not test for Swift Package Manager support usage or something like that(Can you check this functionality)
Tested for iPhone 15 Simulator.
I tried the error and the solution on the same device