### PR TITLE
fix: add preconcurrency annotation in swift api

### DIFF
--- a/ios/app_settings/Sources/app_settings/AppSettingsPlugin.swift
+++ b/ios/app_settings/Sources/app_settings/AppSettingsPlugin.swift
@@ -3,7 +3,7 @@ import UIKit
 import StoreKit
 
 @MainActor
-public class AppSettingsPlugin: NSObject, FlutterPlugin, UIWindowSceneDelegate {
+public class AppSettingsPlugin: NSObject, @preconcurrency FlutterPlugin, UIWindowSceneDelegate {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "com.spencerccf.app_settings/methods", binaryMessenger: registrar.messenger())
         let instance = AppSettingsPlugin()


### PR DESCRIPTION
Fixes #245 occurring in Flutter 3.32.x

_Uses a solution originally posted by @dboune in [#245](https://github.com/spencerccf/app_settings/issues/245#issuecomment-2908649087)_