### PR TITLE
Support AGP 9.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,8 +25,12 @@ allprojects {
     }
 }
 
+def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!isAgp9OrAbove) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdkVersion 36
@@ -38,8 +42,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+    if (!isAgp9OrAbove) {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_11
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Starting with Android Gradle Plugin 9.0, Kotlin support is embedded in
AGP itself and applying the standalone `kotlin-android` plugin causes a
build failure.

This PR detects the AGP version and skips both the plugin application
and the `kotlinOptions` block when running on AGP 9 or above, keeping
the existing behavior unchanged for AGP 8.x and below.

Same approach used by [file_picker](https://github.com/miguelpruivo/flutter_file_picker)
since version 10.x.