### PR TITLE
Use property-style DSL for compileSdk/minSdk (AGP 9 newDsl compatibility)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ if (!isAgp9OrAbove) {
 }
 
 android {
-    compileSdkVersion 36
+    compileSdk = 36
 
     namespace 'com.spencerccf.app_settings'
     
@@ -53,7 +53,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdk = 16
     }
 }
 


### PR DESCRIPTION
Starting with Android Gradle Plugin 9.0, the new DSL is the default and the `compileSdkVersion(...)` / `minSdkVersion(...)` methods are no longer available. Consumers currently have to keep `android.newDsl=false` in `gradle.properties` to build an app that depends on app_settings.

This PR switches the two calls to the equivalent property assignments:

```
compileSdkVersion 36  ->  compileSdk = 36
minSdkVersion 16      ->  minSdk = 16
```

Both properties have existed since AGP 7.0, so this needs no version detection and behaviour on AGP 7.x/8.x is unchanged — the values themselves are untouched.

Follow-up to #270, which handled the `kotlin-android` side of AGP 9 support; this removes the remaining reason for consumers to keep the `newDsl=false` flag. Ref #275.

Same style is already used by e.g. [connectivity_plus](https://pub.dev/packages/connectivity_plus) (`compileSdk = flutter.compileSdkVersion`) and [audio_session](https://pub.dev/packages/audio_session) (`compileSdk = 35` / `minSdk = 19`).