### PR TITLE
fix(ios): raise SwiftPM iOS platform minimum to 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.0.0
+- BREAKING: raise SwiftPM iOS platform minimum to 13.0- [#284](https://github.com/spencerccf/app_settings/pull/284)
+
 ## 8.0.3
 - `android/build.gradle` now reads the actual `android.builtInKotlin` Gradle property (inherited from the consuming app's root project) instead of guessing from the AGP major version alone. `kotlin-android` is only skipped for consumers who have genuinely opted into AGP's built-in Kotlin support; it's still applied (avoiding the 8.0.1 bug) for the default `android.builtInKotlin=false`. Verified both branches against a real AGP 9.0.1 project: with the default `false`, the plugin builds correctly; with `true`, skipping `kotlin-android` avoids the `'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0` failure that other still-unmigrated plugins in the same build hit.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "8.0.2"
+    version: "9.0.0"
   async:
     dependency: transitive
     description:

--- a/ios/app_settings/Package.swift
+++ b/ios/app_settings/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "app_settings",
     platforms: [
-        .iOS("12.0"),
+        .iOS("13.0"),
         .macOS("10.14")
     ],
     products: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app_settings
 description: A Flutter plugin for opening iOS and Android phone settings from an app.
 
-version: 8.0.3
+version: 9.0.0
 
 homepage: https://github.com/spencerccf/app_settings
 


### PR DESCRIPTION
## Problem

With Flutter ≥ 3.41, the plugin's Swift package depends on the Flutter-generated `FlutterFramework` package, which declares a minimum platform of iOS 13.0 (Flutter dropped iOS 12 support). SwiftPM does not allow a package to depend on another package with a higher platform minimum, so building/archiving an app fails with:

```
error: The package product 'FlutterFramework' requires minimum platform version 13.0
for the iOS platform, but this target supports 12.0
(in target 'app_settings' from project 'app_settings')
```

## Fix

Raise the declared iOS minimum in `ios/app_settings/Package.swift` from 12.0 to 13.0. Since Flutter itself requires iOS ≥ 13 (and current stable requires higher), this does not reduce the plugin's effective compatibility for any Flutter app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)