### PR TITLE
fix(ios): bump Package.swift platform to iOS 13.0 for Flutter 3.47 compatibility

### DIFF
--- a/ios/app_settings/Package.swift
+++ b/ios/app_settings/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "app_settings",
     platforms: [
-        .iOS("12.0"),
-        .macOS("10.14")
+        .iOS("13.0"),
+        .macOS("10.15")
     ],
     products: [
         .library(


### PR DESCRIPTION
## Problem

Flutter 3.47's generated `FlutterFramework` SPM package declares `platforms: [.iOS("13.0")]`. The current `Package.swift` declares `.iOS("12.0")`, which causes SPM `Target Integrity` errors:

```
Target Integrity (Xcode): FlutterFramework requires minimum platform version 13.0
for the iOS platform, but this target supports 12.0
```

This blocks iOS builds under Flutter 3.47 + Xcode 26.5+ with SPM enabled.

## Fix

Bump `.iOS("12.0")` -> `.iOS("13.0")` and `.macOS("10.14")` -> `.macOS("10.15")` so the SPM package manifest is compatible with Flutter 3.47's FlutterFramework platform requirement.

No Dart API changes. Tested: iOS integration tests build and run on Xcode 26.6 + Flutter 3.47.